### PR TITLE
Fix `-Waddress-of-packed-member`

### DIFF
--- a/libmpq/explode.c
+++ b/libmpq/explode.c
@@ -145,8 +145,9 @@ static int32_t skip_bit(pkzip_cmp_s *mpq_pkzip, uint32_t bits) {
 	/* load input buffer if necessary. */
 	mpq_pkzip->bit_buf >>= mpq_pkzip->extra_bits;
 	if (mpq_pkzip->in_pos == mpq_pkzip->in_bytes) {
-		mpq_pkzip->in_pos = sizeof(mpq_pkzip->in_buf);
-		if ((mpq_pkzip->in_bytes = mpq_pkzip->read_buf((char *)mpq_pkzip->in_buf, &mpq_pkzip->in_pos, mpq_pkzip->param)) == 0) {
+		uint32_t in_pos = sizeof(mpq_pkzip->in_buf);
+		if ((mpq_pkzip->in_bytes = mpq_pkzip->read_buf((char *)mpq_pkzip->in_buf, &in_pos, mpq_pkzip->param)) == 0) {
+			mpq_pkzip->in_pos = in_pos;
 			return 1;
 		}
 		mpq_pkzip->in_pos = 0;
@@ -538,8 +539,10 @@ uint32_t libmpq__do_decompress_pkzip(uint8_t *work_buf, void *param) {
 	mpq_pkzip->read_buf   = data_read_input;
 	mpq_pkzip->write_buf  = data_write_output;
 	mpq_pkzip->param      = param;
-	mpq_pkzip->in_pos     = sizeof(mpq_pkzip->in_buf);
-	mpq_pkzip->in_bytes   = mpq_pkzip->read_buf((char *)mpq_pkzip->in_buf, &mpq_pkzip->in_pos, mpq_pkzip->param);
+
+	uint32_t in_pos = sizeof(mpq_pkzip->in_buf);
+	mpq_pkzip->in_bytes = mpq_pkzip->read_buf((char *)mpq_pkzip->in_buf, &in_pos, mpq_pkzip->param);
+	mpq_pkzip->in_pos = in_pos;
 
 	/* check if we have pkzip data. */
 	if (mpq_pkzip->in_bytes <= 4) {

--- a/libmpq/mpq.c
+++ b/libmpq/mpq.c
@@ -693,12 +693,14 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 		if (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_ENCRYPTED) {
 
 			/* check if we don't know the file seed, try to find it. */
-			if (libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &mpq_archive->mpq_file[file_number]->seed) < 0) {
+			uint32_t seed;
+			if (libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &seed) < 0) {
 
 				/* sorry without seed, we cannot extract file. */
 				result = LIBMPQ_ERROR_DECRYPT;
 				goto error;
 			}
+			mpq_archive->mpq_file[file_number]->seed = seed;
 
 			/* decrypt block in input buffer. */
 			if (libmpq__decrypt_block(mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->mpq_file[file_number]->seed - 1) < 0 ) {


### PR DESCRIPTION
Fixes the following warning:

    mpq.c: In function ‘libmpq__block_open_offset’:
    mpq.c:698:128: warning: taking address of packed member of ‘struct <anonymous>’ may result in an unaligned pointer value [-Waddress-of-packed-member]
      698 | pq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &mpq_archive->mpq_file[file_number]->seed) < 0) {
          |                                                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fixes #6