### PR TITLE
Add `libmpq__block_seek`

### DIFF
--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -92,6 +92,7 @@ extern LIBMPQ_API int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t
 extern LIBMPQ_API int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
+extern LIBMPQ_API int32_t libmpq__block_seek(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t file_position, uint32_t *block_number, libmpq__off_t *block_size, uint32_t *block_start_position);
 extern LIBMPQ_API int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This allows implementing an efficient streaming API on top of libmpq. Refs #11