### PR TITLE
An option to use filename-based decryption key

### DIFF
--- a/libmpq/common.c
+++ b/libmpq/common.c
@@ -99,6 +99,31 @@ int32_t libmpq__decrypt_block(uint32_t *in_buf, uint32_t in_size, uint32_t seed)
 	return LIBMPQ_SUCCESS;
 }
 
+/* returns the last component of a path after / or \ */
+static const char *get_basename(const char *filename) {
+	const char *basename = strrchr(filename, '\\');
+	if (*basename != '\0') return basename + 1;
+	basename = strrchr(filename, '/');
+	if (*basename != '\0') return basename + 1;
+	return filename;
+}
+
+int32_t libmpq__encryption_key_from_filename(const char *filename, uint32_t *key) {
+	const char *basename = get_basename(filename);
+	if (*basename == '\0')
+		return LIBMPQ_ERROR_DECRYPT;
+	*key = libmpq__hash_string(basename, 0x300);
+	return LIBMPQ_SUCCESS;
+}
+
+int32_t libmpq__encryption_key_from_filename_v2(const char *filename, uint32_t offset, uint32_t unpacked_size, uint32_t *key) {
+	int32_t result = libmpq__encryption_key_from_filename(filename, key);
+	if (result < 0)
+		return result;
+	*key = (*key + offset) ^ unpacked_size;
+	return LIBMPQ_SUCCESS;
+}
+
 /* function to detect decryption key. */
 int32_t libmpq__decrypt_key(uint8_t *in_buf, uint32_t in_size, uint32_t block_size, uint32_t *key) {
 

--- a/libmpq/common.h
+++ b/libmpq/common.h
@@ -49,6 +49,20 @@ int32_t libmpq__decrypt_key(
 	uint32_t	*key
 );
 
+/* function to obtain the decryption key given a filename. */
+int32_t libmpq__encryption_key_from_filename(
+	const char	*filename,
+	uint32_t	*key
+);
+
+/* function to obtain the decryption key given a filename for files with LIBMPQ_FLAG_ENCRYPTION_KEY_V2. */
+int32_t libmpq__encryption_key_from_filename_v2(
+	const char	*filename,
+	uint32_t	offset,
+	uint32_t	unpacked_size,
+	uint32_t	*key
+);
+
 /* function to decompress or explode block from archive. */
 int32_t libmpq__decompress_block(
 	uint8_t		*in_buf,

--- a/libmpq/mpq-internal.h
+++ b/libmpq/mpq-internal.h
@@ -43,6 +43,7 @@
 #define LIBMPQ_FLAG_COMPRESS_PKZIP		0x00000100	/* compression made by pkware data compression library. */
 #define LIBMPQ_FLAG_COMPRESS_MULTI		0x00000200	/* multiple compressions. */
 #define LIBMPQ_FLAG_COMPRESS_NONE		0x00000300	/* no compression (no blizzard flag used by myself). */
+#define LIBMPQ_FLAG_ENCRYPTION_KEY_V2		0x00020000	/* File decryption key is additionally derived from file offset and unpacked size. */
 #define LIBMPQ_FLAG_SINGLE			0x01000000	/* file is stored in one single sector, first seen in world of warcraft. */
 #define LIBMPQ_FLAG_CRC				0x04000000	/* compressed block offset table has CRC checksum. */
 

--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -90,6 +90,7 @@ extern LIBMPQ_API int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t
 
 /* generic block processing functions. */
 extern LIBMPQ_API int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
+extern LIBMPQ_API int32_t libmpq__block_open_offset_with_filename(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename);
 extern LIBMPQ_API int32_t libmpq__block_close_offset(mpq_archive_s *mpq_archive, uint32_t file_number);
 extern LIBMPQ_API int32_t libmpq__block_size_unpacked(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, libmpq__off_t *unpacked_size);
 extern LIBMPQ_API int32_t libmpq__block_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t block_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);

--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -87,6 +87,7 @@ extern LIBMPQ_API int32_t libmpq__file_compressed(mpq_archive_s *mpq_archive, ui
 extern LIBMPQ_API int32_t libmpq__file_imploded(mpq_archive_s *mpq_archive, uint32_t file_number, uint32_t *imploded);
 extern LIBMPQ_API int32_t libmpq__file_number(mpq_archive_s *mpq_archive, const char *filename, uint32_t *number);
 extern LIBMPQ_API int32_t libmpq__file_read(mpq_archive_s *mpq_archive, uint32_t file_number, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
+extern LIBMPQ_API int32_t libmpq__file_read_with_filename(mpq_archive_s *mpq_archive, uint32_t file_number, const char *filename, uint8_t *out_buf, libmpq__off_t out_size, libmpq__off_t *transferred);
 
 /* generic block processing functions. */
 extern LIBMPQ_API int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_number);


### PR DESCRIPTION
Previously, libmpq tried to brute-force the decryption key based on known contents, and only for packed files.

This caused issues, such as https://github.com/mbroemme/libmpq/issues/13.

Adds a new function, `libmpq__block_open_offset_with_filename`, that uses the filename to obtain the decryption key.